### PR TITLE
購入画面遷移

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,6 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
-    # @user = current_user.nickname
     @image = @item.images[0].image
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
-    @user = current_user.nickname
+    # @user = current_user.nickname
     @image = @item.images[0].image
   end
 

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -7,6 +7,8 @@ class PurchaseController < ApplicationController
     @item = Item.find(params[:item_id])
   end
 
+
+
   def pay
     @item = Item.find(params[:item_id])
     card = Card.where(user_id: current_user.id).first

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -7,8 +7,6 @@ class PurchaseController < ApplicationController
     @item = Item.find(params[:item_id])
   end
 
-
-
   def pay
     @item = Item.find(params[:item_id])
     card = Card.where(user_id: current_user.id).first

--- a/app/views/items/_show.html.haml
+++ b/app/views/items/_show.html.haml
@@ -19,7 +19,7 @@
                 出品者
             .item__detailpage__box__main__text__box__content
               .item__detailpage__box__main__text__box__content__assessment
-                = link_to @user, "/mypage/#{current_user.id}"
+                -# = link_to @user, "/mypage/#{current_user.id}"
               .item__detailpage__box__main__text__box__content__icons
                 = icon('fas', 'smile', class: 'item__detailpage__box__main__text__box__content__icons__1')
                 .item__detailpage__box__main__text__box__content__icons__text
@@ -95,7 +95,10 @@
         .item__detailpage__box__price__pastage
           送料込み
       .item__detailpage__box__purchase
-        = link_to '購入画面に進む',"/items/#{@item.id}/purchase"
+        - if user_signed_in?
+          = link_to '購入画面に進む',"/items/#{@item.id}/purchase"
+        - else current_user  ==  nil
+          = link_to  '購入画面に進む',"/signup/step1"
       .item__detailpage__box__caution
         この商品はゆうゆうカリメル便を利用しているため、アプリからのみ購入できます。
       .item__detailpage__box__matter
@@ -322,3 +325,4 @@
           〉
       .item__detailpage__category__box__2
         パンくずで商品名が入ります
+   

--- a/app/views/items/_show.html.haml
+++ b/app/views/items/_show.html.haml
@@ -97,7 +97,7 @@
       .item__detailpage__box__purchase
         - if user_signed_in?
           = link_to '購入画面に進む',"/items/#{@item.id}/purchase"
-        - else current_user  ==  nil
+        - else 
           = link_to  '購入画面に進む',"/signup/step1"
       .item__detailpage__box__caution
         この商品はゆうゆうカリメル便を利用しているため、アプリからのみ購入できます。

--- a/app/views/items/_show.html.haml
+++ b/app/views/items/_show.html.haml
@@ -19,7 +19,7 @@
                 出品者
             .item__detailpage__box__main__text__box__content
               .item__detailpage__box__main__text__box__content__assessment
-                -# = link_to @user, "/mypage/#{current_user.id}"
+
               .item__detailpage__box__main__text__box__content__icons
                 = icon('fas', 'smile', class: 'item__detailpage__box__main__text__box__content__icons__1')
                 .item__detailpage__box__main__text__box__content__icons__text


### PR DESCRIPTION
# What
メルカリの実装で購入画面を押した際にログインしているユーザーの場合は購入することが可能
ログインしていないユーザーの場合には新規登録画面に進むように実装した

# Why
前のコードだとログインしていないユーザーがボタンを押すことでエラーが生じてしまうため

コメントアウトに関してはコードを再度、利用する可能性あるため残しています