### PR TITLE
画面遷移分岐

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,8 +3,8 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
     @image = @item.images[0].image
-    if current_user.id == @item.saler
-      redirect_to "/mypage/#{@item.id}/item_detail"
+    if user_signed_in? && current_user.id == @item.saler
+      redirect_to mypage_item_detail_path(@item.id)
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,9 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
     @image = @item.images[0].image
+    if current_user.id == @item.saler
+      redirect_to "/mypage/#{@item.id}/item_detail"
+    end
   end
 
 


### PR DESCRIPTION
what
商品を選択した際current user.idとsaler.idが同じであれば商品編集ページに飛ばす記述をした
why
出品者が自身の商品を買える状態になっていたため、出品者が自身の商品を選択するとその商品の編集ページに遷移するようにした